### PR TITLE
Fiks korrekte feilmeldinger til bruker ved 401 og 403

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,10 +29,12 @@ import { ImporterOgValiderProdukter } from "produkter/import/ImporterOgValiderPr
 import Navbar from "felleskomponenter/layout/Navbar";
 import { ImporterOgValiderKatalogfil } from "rammeavtaler/import/ImporterOgValiderKatalogfil";
 import { TilGodkjenning } from "godkjenning/TilGodkjenning";
+import ErrorModal from "felleskomponenter/ErrorModal";
 
 export function App() {
   return (
     <FeilGrense>
+      <ErrorModal />
       <Routes>
         <Route path="/" element={<Startside />} />
         <Route path="/logg-inn" element={<LoggInn />} />

--- a/client/src/felleskomponenter/ErrorModal.tsx
+++ b/client/src/felleskomponenter/ErrorModal.tsx
@@ -20,7 +20,7 @@ const ErrorModal = () => {
 
   const getUserErrorMessage = () => {
     if (errorCode === 401) {
-      return "Du er ikke lenger logget inn. Du må logge inn på nytt dersom du ønsker å fortsette";
+      return "Du må logge inn på nytt dersom du ønsker å fortsette";
     }
     if (errorCode === 403) {
       return "Du har ikke tilgang til å utføre denne operasjonen";
@@ -33,11 +33,17 @@ const ErrorModal = () => {
     return `${errorCode}: ${errorMessage} 😣 Beklager, her skjedde det noe som ikke skal skje. Våre utviklere er på saken.`;
   };
 
+  const heading = () => {
+    if (errorCode === 401) return "Du er ikke lenger logget inn";
+    else if (errorCode === 403) return "Du har ikke tilgang";
+    else return "Ups, det skjedde en feil 😱";
+  };
+
   return (
     <Modal
       open={errorCode ? true : false}
       header={{
-        heading: "Ups, det skjedde en feil 😱",
+        heading: heading(),
         closeButton: true,
       }}
       onClose={handleClose}

--- a/client/src/leverandor/LeverandørProfil.tsx
+++ b/client/src/leverandor/LeverandørProfil.tsx
@@ -8,12 +8,13 @@ import { useParams } from "react-router-dom";
 import { HM_REGISTER_URL } from "environments";
 import SupplierInfo from "felleskomponenter/supplier/SupplierInfo";
 import SupplierUsers from "felleskomponenter/supplier/SupplierUsers";
+import { useHydratedErrorStore } from "utils/store/useErrorStore";
 
 const LeverandørProfil = () => {
-  const [error, setError] = useState<Error | null>(null);
   const [supplier, setSupplier] = useState<Supplier>();
   const [supplierUsers, setSupplierUsers] = useState<SupplierUser[]>([]);
   const [isLoading, setLoading] = useState(false);
+  const { setGlobalError } = useHydratedErrorStore();
 
   const { id } = useParams();
 
@@ -26,9 +27,11 @@ const LeverandørProfil = () => {
       credentials: "include",
     })
       .then((res) => {
-        return res.json();
+        if (!res.ok) setGlobalError(res.status, res.statusText);
+        else return res.json();
       })
       .then((data) => {
+        if (!data) return;
         setSupplier(mapSupplier(data));
         if (data) {
           fetch(`${HM_REGISTER_URL()}/admreg/admin/api/v1/users/supplierId/` + id, {
@@ -45,10 +48,6 @@ const LeverandørProfil = () => {
               setLoading(false);
             });
         }
-      })
-      .catch((e) => {
-        setError(e);
-        setLoading(false);
       });
 
     setLoading(false);

--- a/client/src/produkter/OpprettProdukt.tsx
+++ b/client/src/produkter/OpprettProdukt.tsx
@@ -3,7 +3,6 @@ import { Button, Heading, TextField } from "@navikt/ds-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import "./create-product.scss";
-import React from "react";
 import { createNewProductSchema } from "utils/zodSchema/newProduct";
 import { useHydratedErrorStore } from "utils/store/useErrorStore";
 import { useIsoCategories } from "utils/swr-hooks";
@@ -11,7 +10,6 @@ import { useNavigate } from "react-router-dom";
 import { ProductDraftWithDTO } from "utils/types/response-types";
 import { labelRequired } from "utils/string-util";
 import { HM_REGISTER_URL } from "environments";
-import { useAuthStore } from "utils/store/useAuthStore";
 import Combobox from "felleskomponenter/Combobox";
 
 type FormData = z.infer<typeof createNewProductSchema>;
@@ -29,12 +27,6 @@ export default function OpprettProdukt() {
     resolver: zodResolver(createNewProductSchema),
     mode: "onSubmit",
   });
-  const { loggedInUser } = useAuthStore();
-
-  const createProductDraftPath = () =>
-    loggedInUser?.isAdmin
-      ? `${HM_REGISTER_URL()}/admreg/admin/api/v1/product/registrations/draftWith`
-      : `${HM_REGISTER_URL()}/admreg/vendor/api/v1/product/registrations/draftWith`;
 
   async function onSubmit(data: FormData) {
     const newProduct: ProductDraftWithDTO = {
@@ -43,7 +35,7 @@ export default function OpprettProdukt() {
       isoCategory: data.isoCategory,
     };
 
-    const response = await fetch(createProductDraftPath(), {
+    const response = await fetch(`${HM_REGISTER_URL()}/admreg/vendor/api/v1/product/registrations/draftWith`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/src/profil/Profil.tsx
+++ b/client/src/profil/Profil.tsx
@@ -5,6 +5,7 @@ import SupplierUsers from "felleskomponenter/supplier/SupplierUsers";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "utils/store/useAuthStore";
+import { useHydratedErrorStore } from "utils/store/useErrorStore";
 import { Supplier, SupplierUser, mapSupplier } from "utils/supplier-util";
 
 export default function Profil() {
@@ -14,6 +15,8 @@ export default function Profil() {
   const [supplierUsers, setSupplierUsers] = useState<SupplierUser[]>([]);
   const [isLoading, setLoading] = useState(false);
   const { loggedInUser } = useAuthStore();
+
+  const { setGlobalError } = useHydratedErrorStore();
 
   useEffect(() => {
     if (loggedInUser?.isAdmin) {
@@ -29,9 +32,11 @@ export default function Profil() {
       credentials: "include",
     })
       .then((res) => {
-        return res.json();
+        if (!res.ok) setGlobalError(res.status, res.statusText);
+        else return res.json();
       })
       .then((data) => {
+        if (!data) return;
         setSupplier(mapSupplier(data));
 
         fetch(`${HM_REGISTER_URL()}/admreg/vendor/api/v1/users`, {
@@ -52,7 +57,7 @@ export default function Profil() {
         setError(e);
         setLoading(false);
       });
-  }, []);
+  }, [setGlobalError]);
 
   if (isLoading) return <Loader size="3xlarge" title="Henter brukeropplysninger" />;
   if (error)

--- a/client/src/utils/store/useErrorStore.ts
+++ b/client/src/utils/store/useErrorStore.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { create } from "zustand";
 
 type ErrorCode = number;
@@ -10,7 +9,7 @@ type Error = {
   clearError: () => void;
 };
 
-const useErrorStore = create<Error>((set) => ({
+export const useHydratedErrorStore = create<Error>((set) => ({
   errorCode: undefined,
   errorMessage: undefined,
   setGlobalError: (errorCode, errorMessage) => set({ errorCode, errorMessage }),
@@ -18,17 +17,3 @@ const useErrorStore = create<Error>((set) => ({
     set({ errorCode: undefined, errorMessage: undefined });
   },
 }));
-
-export const useHydratedErrorStore = ((selector, compare) => {
-  const store = useErrorStore(selector, compare);
-  const [hydrated, setHydrated] = useState(false);
-  useEffect(() => setHydrated(true), []);
-  return hydrated
-    ? store
-    : {
-        errorCode: undefined,
-        errorMessage: undefined,
-        setGlobalError: (_errorCode: ErrorCode, _errorMessage?: string) => {},
-        clearError: () => {},
-      };
-}) as typeof useErrorStore;


### PR DESCRIPTION
- Bruker ble ikke rett redirected dersom man har latt siden stå lenge og egentlig er logget ut. Så at vi ikke håndterer feil på rett måte i profil og leverandørprofil samt at ErrorModal som skal vise feil til brukeren ikke ble brukt. Derfor ble man ikke sendt til /logg-inn. Fikser slik at feil ved kall settes i GlobalErrorState i stedet for en lokal state som ikke ble brukt. 

- Endrer litt på teksten til ErrorModal. Disse tekstene er ok ved 401 og 403, men dersom andre feil skjer er det ikke sikkert at vi alltid vil vise en global med feilmelding fra server med overskrift "ups det skjedde en feil". Her må vi teste oss frem og tenke oss godt om når lager kode med kall til server slik at vi lager riktig håndtering av feil i hvert use case. 

- Fjerner også hydering av global state, da dette var noe vi måtte gjøre ved brukt av Next og serverside. Den globale staten fungerte ikke med hydrering. 
 