### PR TITLE
videolink warning for suppliers

### DIFF
--- a/client/src/produkter/VideosTab.tsx
+++ b/client/src/produkter/VideosTab.tsx
@@ -136,9 +136,10 @@ const VideoTab = ({ products, mutateProducts }: { products: ProductRegistrationD
         )}
 
         <Alert variant="warning">
-          Sørg for at videoen som lenkes til er tekstet og at kravene til universell utforming følges. De som ikke kan
-          høre lyd skal få presentert lydinnholdet på en alternativ måte. Dette er lovpålagt.
-          <Link href="https://www.uutilsynet.no/veiledning/video-og-lydopptak/232#videoopptak_med_lyd">
+          Sørg for at videoen som lenkes til er tekstet, har synstolking og at kravene til universell utforming følges.
+          De som ikke kan høre lyd skal for eksempel få presentert lydinnholdet på en alternativ måte. Dette er
+          lovpålagt.
+          <Link href="https://www.uutilsynet.no/wcag-standarden/12-tidsbaserte-medier/743">
             Ytterligere informasjon om teksting av videoer finnes på nettsidene til Tilsynet for universell utforming av
             ikt
           </Link>

--- a/client/src/produkter/VideosTab.tsx
+++ b/client/src/produkter/VideosTab.tsx
@@ -129,7 +129,7 @@ const VideoTab = ({ products, mutateProducts }: { products: ProductRegistrationD
   return (
     <Tabs.Panel value="videos" className="tab-panel">
       <VStack gap="8">
-        {videos.length !== 0 && (
+        {videos.length === 0 && (
           <Alert variant="info">
             Produktet har ingen videolenker. Det er kun mulig å legge til lenker fra YouTube og Vimeo.
           </Alert>

--- a/client/src/produkter/VideosTab.tsx
+++ b/client/src/produkter/VideosTab.tsx
@@ -129,11 +129,20 @@ const VideoTab = ({ products, mutateProducts }: { products: ProductRegistrationD
   return (
     <Tabs.Panel value="videos" className="tab-panel">
       <VStack gap="8">
-        {videos.length === 0 && (
+        {videos.length !== 0 && (
           <Alert variant="info">
             Produktet har ingen videolenker. Det er kun mulig å legge til lenker fra YouTube og Vimeo.
           </Alert>
         )}
+
+        <Alert variant="warning">
+          Sørg for at videoen som lenkes til er tekstet og at kravene til universell utforming følges. De som ikke kan
+          høre lyd skal få presentert lydinnholdet på en alternativ måte. Dette er lovpålagt.
+          <Link href="https://www.uutilsynet.no/veiledning/video-og-lydopptak/232#videoopptak_med_lyd">
+            Ytterligere informasjon om teksting av videoer finnes på nettsidene til Tilsynet for universell utforming av
+            ikt
+          </Link>
+        </Alert>
 
         {videos.length > 0 && (
           <HStack as="ol" className="videos" gap="4">


### PR DESCRIPTION
<img width="1263" alt="image" src="https://github.com/navikt/hm-adminregister/assets/56063879/7e8e7c3e-0871-4f29-be96-fa721921206c">
 
Den gule står alltid der. Den lilla forsvinner om man har lagt til lenker. Forslag til tekstforbedring?