### PR TITLE
Rediger filnavn inne i upload modal

### DIFF
--- a/client/src/felleskomponenter/ImageCard.tsx
+++ b/client/src/felleskomponenter/ImageCard.tsx
@@ -23,7 +23,7 @@ export const ImageCard = ({ mediaInfo, handleDeleteFile, showMenuButton = true }
           <ImageContainer uri={mediaInfo.uri} text={mediaInfo.text} onClick={() => setImageModalIsOpen(true)} />
           <VStack gap="1" align="center">
             <i>Filnavn</i>{" "}
-            <span className="text-overflow-hidden">{mediaInfo.filename ?? "OBS mangler beskrivelse"}</span>
+            <span className="text-overflow-hidden-small">{mediaInfo.filename ?? "OBS mangler beskrivelse"}</span>
           </VStack>
         </VStack>
         {showMenuButton && (

--- a/client/src/felleskomponenter/MoreMenu.tsx
+++ b/client/src/felleskomponenter/MoreMenu.tsx
@@ -43,7 +43,7 @@ export const MoreMenu = ({
                 onClick={() => handleEditFileName(mediaInfo.uri)}
                 icon={<PencilWritingIcon title="rediger" fontSize="1.5rem" />}
               >
-                Rediger filnavn
+                Endre filnavn
               </Button>
             )}
 

--- a/client/src/felleskomponenter/layout/ProfileMenu.tsx
+++ b/client/src/felleskomponenter/layout/ProfileMenu.tsx
@@ -49,7 +49,7 @@ const ProfileMenu = () => {
               <Buldings3Icon title="Building icon" fontSize="2.25rem" />
             )}
             <VStack align={"start"}>
-              <BodyShort className="text-overflow-hidden">
+              <BodyShort className="text-overflow-hidden-small">
                 {loggedInUser?.isAdmin ? "Administrator" : loggedInUser?.supplierName}
               </BodyShort>
               <BodyShort size="small">{loggedInUser?.userName}</BodyShort>

--- a/client/src/produkter/Produkt.tsx
+++ b/client/src/produkter/Produkt.tsx
@@ -26,7 +26,7 @@ import { useErrorStore } from "utils/store/useErrorStore";
 import { IsoCategoryDTO, ProductRegistrationDTO } from "utils/types/response-types";
 import { fetcherGET } from "utils/swr-hooks";
 import { HM_REGISTER_URL } from "environments";
-import { publishProducts, rejectProducts, updateProduct } from "api/ProductApi";
+import { updateProduct } from "api/ProductApi";
 import StatusPanel from "produkter/StatusPanel";
 import {
   CogIcon,

--- a/client/src/produkter/import/valideringsside/ValiderImporterteProdukter.tsx
+++ b/client/src/produkter/import/valideringsside/ValiderImporterteProdukter.tsx
@@ -1,5 +1,5 @@
 import { Alert, BodyShort, Button, ExpansionCard, Heading, HStack, Loader } from "@navikt/ds-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuthStore } from "utils/store/useAuthStore";
 import { Product } from "utils/types/types";
 import { mapProductRegistrationDTOToProduct } from "utils/product-util";
@@ -7,7 +7,6 @@ import { Upload } from "produkter/import/ImporterProdukter";
 import { ProductSeriesInfo } from "produkter/import/valideringsside/ProductSeriesInfo";
 import { VariantsTable } from "produkter/import/valideringsside/VariantsTable";
 import { baseUrl, useIsoCategories } from "utils/swr-hooks";
-import { useNavigate } from "react-router-dom";
 import { importProducts } from "api/ImportExportApi";
 
 interface Props {
@@ -20,9 +19,8 @@ export const ValiderImporterteProdukter = ({ upload, reseetUpload }: Props) => {
   const [productsToValidate, setProductsToValidate] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
-  const { isoCategories, isoError } = useIsoCategories();
+  const { isoCategories } = useIsoCategories();
   const [importSuccessful, setImportSuccessful] = useState(false);
-  const navigate = useNavigate();
 
   const uniqueIsoCodes = isoCategories?.filter((cat) => cat.isoCode && cat.isoCode.length >= 8);
   const isoCodesAndTitles = uniqueIsoCodes?.map((cat) => cat.isoCode + " - " + cat.isoTitle);
@@ -133,7 +131,7 @@ export const ValiderImporterteProdukter = ({ upload, reseetUpload }: Props) => {
                     size="medium"
                     variant="primary"
                     iconPosition="right"
-                    onClick={(event) => {
+                    onClick={() => {
                       importer();
                     }}
                   >
@@ -143,24 +141,22 @@ export const ValiderImporterteProdukter = ({ upload, reseetUpload }: Props) => {
 
                 {productsToValidate.map((product, i) => {
                   return (
-                    <div>
-                      <ExpansionCard
-                        key={i}
-                        aria-label="Produktserie med varianter"
-                        style={{ width: "90vw" }}
-                        size="small"
-                      >
-                        <ExpansionCard.Header>
-                          <ExpansionCard.Title>{product.title}</ExpansionCard.Title>
-                          <ExpansionCard.Description>
-                            <ProductSeriesInfo product={product} />
-                          </ExpansionCard.Description>
-                        </ExpansionCard.Header>
-                        <ExpansionCard.Content>
-                          <VariantsTable product={product} />
-                        </ExpansionCard.Content>
-                      </ExpansionCard>
-                    </div>
+                    <ExpansionCard
+                      key={i}
+                      aria-label="Produktserie med varianter"
+                      style={{ width: "90vw" }}
+                      size="small"
+                    >
+                      <ExpansionCard.Header>
+                        <ExpansionCard.Title>{product.title}</ExpansionCard.Title>
+                        <ExpansionCard.Description>
+                          <ProductSeriesInfo product={product} />
+                        </ExpansionCard.Description>
+                      </ExpansionCard.Header>
+                      <ExpansionCard.Content>
+                        <VariantsTable product={product} />
+                      </ExpansionCard.Content>
+                    </ExpansionCard>
                   );
                 })}
               </HStack>

--- a/client/src/produkter/product-page.scss
+++ b/client/src/produkter/product-page.scss
@@ -37,7 +37,7 @@ pre {
   padding-left: 0;
 
   li {
-    padding: $a-spacing-2 $a-spacing-4;
+    padding: $a-spacing-4 $a-spacing-4;
     background-color: #ffffff;
     box-shadow: $a-shadow-xsmall;
     border-radius: $a-border-radius-medium;
@@ -49,10 +49,6 @@ pre {
     li {
       width: 100%;
       padding: $a-spacing-4 $a-spacing-4;
-
-      .navds-form-field {
-        gap: 0;
-      }
     }
   }
 }
@@ -81,7 +77,7 @@ pre {
   display: flex;
   justify-content: center;
   position: relative;
-  :hover{
+  :hover {
     cursor: pointer;
     opacity: 0.7;
   }

--- a/client/src/produkter/productUtils.ts
+++ b/client/src/produkter/productUtils.ts
@@ -2,19 +2,22 @@ import { isUUID } from "utils/string-util";
 import { ProductRegistrationDTO } from "utils/types/response-types";
 
 export const numberOfImages = (products: ProductRegistrationDTO[]) => {
-  return products[0].productData.media.filter((media) => media.type == "IMAGE").length;
+  const media = products[0]?.productData?.media || [];
+  return media.filter((media) => media?.type === "IMAGE").length;
 };
 
 export const numberOfDocuments = (products: ProductRegistrationDTO[]) => {
-  return products[0].productData.media.filter((media) => media.type == "PDF").length;
+  const media = products[0]?.productData?.media || [];
+  return media.filter((media) => media?.type === "PDF").length;
 };
 
 export const numberOfVideos = (products: ProductRegistrationDTO[]) => {
-  return products[0].productData.media.filter((media) => media.type == "VIDEO" && media.source === "EXTERNALURL").length;
+  const media = products[0]?.productData?.media || [];
+  return media.filter((media) => media?.type === "VIDEO" && media?.source === "EXTERNALURL").length;
 };
 
 export const numberOfVariants = (products: ProductRegistrationDTO[]) => {
-  if (isUUID(products[0].supplierRef)) {
+  if (isUUID(products[0]?.supplierRef)) {
     return 0;
   }
   return products.length;

--- a/client/src/produkter/tabs/DocumentsTab.tsx
+++ b/client/src/produkter/tabs/DocumentsTab.tsx
@@ -148,45 +148,47 @@ const DocumentListItem = ({
 
   return (
     <>
-      <HStack as="li" justify="space-between" align="center">
+      <HStack as="li" justify="space-between" wrap={false}>
         {editMode ? (
-          <HStack style={{ width: "100%" }} justify="space-between">
-            <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
-              <FilePdfIcon fontSize="2rem" />
-              <TextField
-                ref={containerRef}
-                className="inputfield"
-                style={{ width: `${textLength}ch`, maxWidth: "550px" }}
-                label=""
-                value={editedFileText}
-                onChange={(event) => setEditedFileText(event.currentTarget.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    handleSaveFileName();
-                  }
-                }}
+          <>
+            <TextField
+              ref={containerRef}
+              style={{ width: `${textLength}ch`, maxWidth: "550px", minWidth: "450px" }}
+              label="Endre filnavn"
+              value={editedFileText}
+              onChange={(event) => setEditedFileText(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handleSaveFileName();
+                }
+              }}
+            />
+            <HStack align="end">
+              <Button
+                variant="tertiary"
+                title="Lagre"
+                onClick={handleSaveFileName}
+                icon={<FloppydiskIcon fontSize="2rem" />}
               />
             </HStack>
-            <Button
-              size="xsmall"
-              variant="tertiary"
-              onClick={handleSaveFileName}
-              icon={<FloppydiskIcon title="Lagre" fontSize="2rem" />}
-            >
-              Lagre
-            </Button>
-          </HStack>
+          </>
         ) : (
           <>
-            <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center">
+            <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
               <FilePdfIcon fontSize="2rem" />
-              <a href={file.sourceUri} target="_blank" rel="noreferrer">
+              <a href={file.sourceUri} target="_blank" rel="noreferrer" className="text-overflow-hidden">
                 {file.text || file.uri.split("/").pop()}
               </a>
             </HStack>
             {isEditable && (
-              <MoreMenu mediaInfo={file} handleDeleteFile={handleDeleteFile} handleEditFileName={handleEditFileName} />
+              <HStack>
+                <MoreMenu
+                  mediaInfo={file}
+                  handleDeleteFile={handleDeleteFile}
+                  handleEditFileName={handleEditFileName}
+                />
+              </HStack>
             )}
           </>
         )}

--- a/client/src/produkter/tabs/DocumentsTab.tsx
+++ b/client/src/produkter/tabs/DocumentsTab.tsx
@@ -177,7 +177,7 @@ const DocumentListItem = ({
         <>
           <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
             <FilePdfIcon fontSize="2rem" />
-            <a href={uriForMediaFile(file)} target="_blank" rel="noreferrer" className="text-overflow-hidden">
+            <a href={uriForMediaFile(file)} target="_blank" rel="noreferrer" className="text-overflow-hidden-large">
               {file.text || file.uri.split("/").pop()}
             </a>
           </HStack>

--- a/client/src/produkter/tabs/DocumentsTab.tsx
+++ b/client/src/produkter/tabs/DocumentsTab.tsx
@@ -148,52 +148,46 @@ const DocumentListItem = ({
   const textLength = editedFileText.length + 4;
 
   return (
-    <>
-      <HStack as="li" justify="space-between" wrap={false}>
-        {editMode ? (
-          <>
-            <TextField
-              ref={containerRef}
-              style={{ width: `${textLength}ch`, maxWidth: "550px", minWidth: "450px" }}
-              label="Endre filnavn"
-              value={editedFileText}
-              onChange={(event) => setEditedFileText(event.currentTarget.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  handleSaveFileName();
-                }
-              }}
+    <HStack as="li" justify="space-between" wrap={false}>
+      {editMode ? (
+        <>
+          <TextField
+            ref={containerRef}
+            style={{ width: `${textLength}ch`, maxWidth: "550px", minWidth: "450px" }}
+            label="Endre filnavn"
+            value={editedFileText}
+            onChange={(event) => setEditedFileText(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleSaveFileName();
+              }
+            }}
+          />
+          <HStack align="end">
+            <Button
+              variant="tertiary"
+              title="Lagre"
+              onClick={handleSaveFileName}
+              icon={<FloppydiskIcon fontSize="2rem" />}
             />
-            <HStack align="end">
-              <Button
-                variant="tertiary"
-                title="Lagre"
-                onClick={handleSaveFileName}
-                icon={<FloppydiskIcon fontSize="2rem" />}
-              />
+          </HStack>
+        </>
+      ) : (
+        <>
+          <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
+            <FilePdfIcon fontSize="2rem" />
+            <a href={uriForMediaFile(file)} target="_blank" rel="noreferrer" className="text-overflow-hidden">
+              {file.text || file.uri.split("/").pop()}
+            </a>
+          </HStack>
+          {isEditable && (
+            <HStack>
+              <MoreMenu mediaInfo={file} handleDeleteFile={handleDeleteFile} handleEditFileName={handleEditFileName} />
             </HStack>
-          </>
-        ) : (
-          <>
-            <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
-              <FilePdfIcon fontSize="2rem" />
-              <a href={uriForMediaFile(file)} target="_blank" rel="noreferrer" className="text-overflow-hidden">
-                {file.text || file.uri.split("/").pop()}
-              </a>
-            </HStack>
-            {isEditable && (
-              <HStack>
-                <MoreMenu
-                  mediaInfo={file}
-                  handleDeleteFile={handleDeleteFile}
-                  handleEditFileName={handleEditFileName}
-                />
-              </HStack>
-            )}
-          </>
-        )}
-      </HStack>
-    </>
+          )}
+        </>
+      )}
+    </HStack>
   );
 };

--- a/client/src/produkter/tabs/UploadModal.tsx
+++ b/client/src/produkter/tabs/UploadModal.tsx
@@ -322,10 +322,10 @@ const Upload = ({
             ) : (
               <FilePdfIcon fontSize="1.5rem" />
             )}
-            <Label className="text-overflow-hidden">{fileName}</Label>
+            <Label className="text-overflow-hidden-large">{fileName}</Label>
           </HStack>
 
-          <HStack>
+          <HStack wrap={false}>
             {fileType === "documents" && (
               <Button
                 variant="tertiary"

--- a/client/src/produkter/tabs/UploadModal.tsx
+++ b/client/src/produkter/tabs/UploadModal.tsx
@@ -1,6 +1,13 @@
-import { FileImageFillIcon, FilePdfIcon, TrashIcon, UploadIcon } from "@navikt/aksel-icons";
-import { BodyLong, BodyShort, Button, HStack, Label, Loader, Modal, VStack } from "@navikt/ds-react";
-import { useRef, useState } from "react";
+import {
+  FileImageFillIcon,
+  FilePdfIcon,
+  FloppydiskIcon,
+  PencilWritingIcon,
+  TrashIcon,
+  UploadIcon,
+} from "@navikt/aksel-icons";
+import { BodyLong, BodyShort, Button, HStack, Label, Loader, Modal, TextField, VStack } from "@navikt/ds-react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useErrorStore } from "utils/store/useErrorStore";
 import { MediaDTO, ProductRegistrationDTO } from "utils/types/response-types";
@@ -17,9 +24,10 @@ interface Props {
   mutateProducts: () => void;
 }
 
-interface Upload {
+export interface Upload {
   file: File;
   previewUrl?: string;
+  editedFileName?: string;
 }
 
 const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProducts }: Props) => {
@@ -37,6 +45,8 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
     for (const upload of uploads) {
       formData.append("files", upload.file);
     }
+
+    //1. save file to media endpoint (here we use js File which means it will always be saved with the original filename. A file cannot be changed)
     let res = await fetch(`${HM_REGISTER_URL()}/admreg/vendor/api/v1/media/product/files/${oid}`, {
       method: "POST",
       headers: {
@@ -50,7 +60,10 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
       setGlobalError(res.status, res.statusText);
       return;
     }
+
     const mediaDTOs: MediaDTO[] = await res.json();
+
+    //2. save file to product with edited filename if the user have changed it (display name)
     //Fetch produkt to update the latest version
     res = await fetch(`${HM_REGISTER_URL()}/admreg/vendor/api/v1/product/registrations/${oid}`, {
       method: "GET",
@@ -66,7 +79,9 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
     }
 
     const productToUpdate: ProductRegistrationDTO = await res.json();
-    const editedProductDTO = mediaDTOs && getEditedProductDTOAddMedia(productToUpdate, mapToMediaInfo(mediaDTOs));
+
+    const editedProductDTO =
+      mediaDTOs && getEditedProductDTOAddMedia(productToUpdate, mapToMediaInfo(mediaDTOs, uploads));
 
     res = await fetch(`${HM_REGISTER_URL()}/admreg/vendor/api/v1/product/registrations/${productToUpdate.id}`, {
       method: "PUT",
@@ -89,7 +104,7 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
   const handleChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event?.currentTarget?.files || []);
 
-    const allChosenFiles = uploads.concat(files.map((file) => ({ file })));
+    const allChosenFiles = uploads.concat(files.map((file) => ({ file, editedFileName: file.name }))); // Add editedFileName
     setUploads(allChosenFiles);
 
     Promise.all(files.map(fileToUri)).then((urls) => {
@@ -102,15 +117,14 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
     });
   };
 
-  const handleDelete = (event: React.MouseEvent<HTMLButtonElement>, file: File) => {
-    event.preventDefault();
+  const handleDelete = (file: File) => {
     const filteredFiles = uploads.filter((upload) => upload.file !== file);
     setUploads(filteredFiles);
   };
 
   const handleDragEvent = (event: React.DragEvent<HTMLDivElement>) => {
     setFileTypeError("");
-    //NB! Må sjekke at det er et bilde.. kan droppe hvilken som helst fil
+    //Check is file is a picture as it is possible to drop any type of file
     event.preventDefault();
     const acceptedFileTypesImages = ["image/jpeg", "image/jpg", "image/png"];
     const acceptedFileTypesDocuments = ["application/pdf"];
@@ -141,6 +155,15 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
       );
     });
   };
+
+  const setEditedFileName = (upload: Upload, newFileName: string) => {
+    setUploads((prevUploads) =>
+      prevUploads.map((prevUpload) =>
+        prevUpload.previewUrl === upload.previewUrl ? { ...prevUpload, editedFileName: newFileName } : prevUpload,
+      ),
+    );
+  };
+
   return (
     <Modal
       open={modalIsOpen}
@@ -192,30 +215,20 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
 
           {fileTypeError && <BodyLong>{fileTypeError}</BodyLong>}
           <VStack as="ol" gap="3" className="images-inline">
-            {uploads.map((upload, i) => (
-              <HStack as="li" justify="space-between" align="center" key={`upload-${i}`}>
-                <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center">
-                  {fileType === "images" ? (
-                    <ImageContainer uri={upload.previewUrl} size="xsmall" />
-                  ) : (
-                    <FilePdfIcon fontSize="1.5rem" />
-                  )}
-
-                  <Label>{upload.file.name}</Label>
-                </HStack>
-                <Button
-                  variant="tertiary"
-                  icon={<TrashIcon />}
-                  title="slett"
-                  onClick={(event) => handleDelete(event, upload.file)}
-                />
-              </HStack>
+            {uploads.map((upload) => (
+              <Upload
+                key={`${upload.file.name}`}
+                upload={upload}
+                fileType={fileType}
+                handleDelete={handleDelete}
+                setEditedFileName={setEditedFileName}
+              />
             ))}
           </VStack>
         </Modal.Body>
         <Modal.Footer>
           <Button type="submit" variant="primary">
-            Lagre
+            Last opp
           </Button>
           <Button
             onClick={(event) => {
@@ -233,3 +246,110 @@ const UploadModal = ({ modalIsOpen, oid, fileType, setModalIsOpen, mutateProduct
 };
 
 export default UploadModal;
+
+const Upload = ({
+  upload,
+  fileType,
+  handleDelete,
+  setEditedFileName,
+}: {
+  upload: Upload;
+  fileType: "images" | "documents";
+  handleDelete: (file: File) => void;
+  setEditedFileName: (upload: Upload, newfileName: string) => void;
+}) => {
+  //Need to initialize filName state with file.name because thats what the user chooses to upload. Then they can change it.
+  const [fileName, setFileName] = useState(upload.file.name);
+  const [editMode, setEditMode] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const fileNameInputRef = useRef<HTMLInputElement>(null);
+
+  const handleChangeFileName = () => {
+    setEditMode(false);
+    setEditedFileName(upload, fileName);
+  };
+
+  useEffect(() => {
+    if (editMode && fileNameInputRef.current) {
+      fileNameInputRef.current.focus();
+    }
+  }, [editMode]);
+
+  const validateFileName = () => {
+    setErrorMessage("");
+    if (fileName.trim().length !== 0) {
+      handleChangeFileName();
+    } else {
+      setErrorMessage("Filen må ha et navn");
+    }
+  };
+
+  return (
+    <HStack as="li" justify="space-between" wrap={false}>
+      {editMode && fileType === "documents" ? (
+        <>
+          <TextField
+            ref={fileNameInputRef}
+            style={{ width: "500px" }}
+            label="Endre filnavn"
+            value={fileName}
+            onChange={(event) => setFileName(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                validateFileName();
+              }
+            }}
+            error={errorMessage}
+          />
+          <HStack align="end">
+            <Button
+              variant="tertiary"
+              title="Lagre"
+              onClick={(event) => {
+                event.preventDefault();
+                validateFileName();
+              }}
+              icon={<FloppydiskIcon fontSize="2rem" />}
+            />
+          </HStack>
+        </>
+      ) : (
+        <>
+          <HStack gap={{ xs: "1", sm: "2", md: "3" }} align="center" wrap={false}>
+            {fileType === "images" ? (
+              <ImageContainer uri={upload.previewUrl} size="xsmall" />
+            ) : (
+              <FilePdfIcon fontSize="1.5rem" />
+            )}
+            <Label className="text-overflow-hidden">{fileName}</Label>
+          </HStack>
+
+          <HStack>
+            {fileType === "documents" && (
+              <Button
+                variant="tertiary"
+                title="rediger"
+                onClick={(event) => {
+                  event.preventDefault();
+                  setEditMode(true);
+                }}
+                icon={<PencilWritingIcon fontSize="1.5rem" />}
+              />
+            )}
+
+            <Button
+              variant="tertiary"
+              title="slett"
+              onClick={(event) => {
+                event.preventDefault();
+                handleDelete(upload.file);
+              }}
+              icon={<TrashIcon fontSize="1.5rem" />}
+            />
+          </HStack>
+        </>
+      )}
+    </HStack>
+  );
+};

--- a/client/src/styles/globals.scss
+++ b/client/src/styles/globals.scss
@@ -142,7 +142,14 @@ main:not(.show-menu) {
   width: fit-content;
 }
 
-.text-overflow-hidden {
+.text-overflow-hidden-small {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.text-overflow-hidden-large {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/client/src/styles/globals.scss
+++ b/client/src/styles/globals.scss
@@ -146,7 +146,7 @@ main:not(.show-menu) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 120px;
+  max-width: 450px;
 }
 
 .max-width {

--- a/client/src/utils/swr-hooks.ts
+++ b/client/src/utils/swr-hooks.ts
@@ -49,10 +49,6 @@ export const fetcherGET: Fetcher<any, string> = (url) =>
     },
   }).then((res) => {
     if (!res.ok) {
-      if (res.status === 401) {
-        window.location.href = `${baseUrl("/logg-inn")}`;
-        return res.json();
-      }
       return res.json().then((data) => {
         throw new CustomError(data.errorMessage || res.statusText, res.status);
       });


### PR DESCRIPTION
TESTES I DEV

- Gjør det mulig å navngi filen slik man selv ønsker allerede inne i modalen der man laster opp bildene. 
NB: Endrer aldri det faktiske filnavnet (det går ikke an på en javascript File). Så filen som lagret på Media-endepunktet forholder seg ikke til dette i det hele tatt. Endrer kun teksten til filen som er knyttet til produktet. Navnet som vises i GUI er file.text hvis det finnes, hvis ikke file.name. 
- Rydder litt opp i V-stack og H-stack
- Skiller ut en Upload i egen komponent
- Kommenterer resten i koden der jeg har gjort noe som ikke handler om filnavn :) 



<img width="801" alt="image" src="https://github.com/navikt/hm-adminregister/assets/56063879/6f3411ca-cf67-4e01-bd1f-9186c611f39b">
<img width="737" alt="image" src="https://github.com/navikt/hm-adminregister/assets/56063879/3120ef0a-e1fa-4dd3-996d-4e439f695cc6">
<img width="797" alt="image" src="https://github.com/navikt/hm-adminregister/assets/56063879/3d0e9e7a-d086-4478-a255-96fc47c97a9f">
<img width="855" alt="image" src="https://github.com/navikt/hm-adminregister/assets/56063879/d96ce1c3-20a8-4d39-b303-f2738fb6bd40">




