### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-env.yml
+++ b/.github/workflows/deploy-env.yml
@@ -21,6 +21,8 @@ jobs:
   test:
     name: run tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/hm-adminregister/security/code-scanning/3](https://github.com/navikt/hm-adminregister/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `test` job to explicitly define the minimal permissions required. Since the `test` job only needs to read the repository contents to check out the code and run tests, the `contents: read` permission is sufficient. This change ensures that the job does not inherit unnecessary permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
